### PR TITLE
fix: fix error when calling Node#insertBefore with null as 2nd argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ notifications:
     email: false
 addons:
     chrome: stable
-    browserstack:
-        forcelocal: true
-        username: nikaplezhou1
-        access_key: ${BROWSERSTACK_KEY}
 node_js:
     - '10'
 script:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assets-retry",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "keywords": [],
   "main": "dist/assets-retry.umd.js",

--- a/src/retry-async.ts
+++ b/src/retry-async.ts
@@ -181,6 +181,7 @@ const hookPrototype = function(target: any) {
         const originalFunc = target[key]
         target[key] = function(): any {
             const args = [].slice.call(arguments).map((item: any) => {
+                if (!item) return item;
                 return hasOwn.call(item, innerScriptProp) ? item[innerScriptProp] : item
             })
             return originalFunc.apply(this, args)

--- a/src/retry-css.ts
+++ b/src/retry-css.ts
@@ -11,6 +11,7 @@ const processRules = function(
     name: UrlProperty,
     rule: CSSStyleRule,
     styleSheet: CSSStyleSheet,
+    styleRules: CSSStyleRule[],
     opts: InnerAssetsRetryOptions
 ) {
     const domainMap = opts.domain
@@ -40,7 +41,7 @@ const processRules = function(
         .join(',')
     const cssText = rule.selectorText + `{ ${toSlug(name)}: ${urlList} !important; }`
     try {
-        styleSheet.insertRule(cssText, getCssRules(styleSheet).length)
+        styleSheet.insertRule(cssText, styleRules.length)
     } catch (_) {
         styleSheet.insertRule(cssText, 0)
     }
@@ -51,10 +52,14 @@ const processStyleSheets = (styleSheets: StyleSheet[], opts: InnerAssetsRetryOpt
     // TODO: iterating stylesheets may cause performance issues
     // maybe find other approaches?
     styleSheets.forEach((styleSheet: any) => {
-        const styleRules = arrayFrom(getCssRules(styleSheet)) as CSSStyleRule[]
+        const rules = getCssRules(styleSheet);
+        if (rules === null) {
+            return;
+        }
+        const styleRules = arrayFrom(rules) as CSSStyleRule[]
         styleRules.forEach(rule => {
             urlProperties.forEach(cssProperty => {
-                processRules(cssProperty, rule, styleSheet, opts)
+                processRules(cssProperty, rule, styleSheet, styleRules, opts)
             })
         })
 

--- a/src/retry-sync.ts
+++ b/src/retry-sync.ts
@@ -119,12 +119,11 @@ export default function initSync(opts: InnerAssetsRetryOptions) {
         const targetStyleSheet = styleSheets.filter(styleSheet => {
             return styleSheet.href === target.href
         })[0]
-        // do not support css rules API
-        if (!targetStyleSheet.rules && !targetStyleSheet.cssRules) {
-            return;
+        const rules = getCssRules(targetStyleSheet)
+        if (rules === null) {
+            return
         }
-        const styleRules = arrayFrom(getCssRules(targetStyleSheet))
-        if (styleRules.length === 0) {
+        if (rules.length === 0) {
             errorHandler(event)
         }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -190,13 +190,15 @@ export const loadNextScript = function(
  * @returns
  */
 export const getCssRules = function(styleSheet: CSSStyleSheet) {
-    if (styleSheet.rules) {
+    try {
         return styleSheet.rules
+    } catch (_) {
+        try {
+            return styleSheet.cssRules
+        } catch (_) {
+            return null
+        }
     }
-    if (styleSheet.cssRules) {
-        return styleSheet.cssRules
-    }
-    return []
 }
 /**
  * test if current browser support CSSRuleList
@@ -205,12 +207,8 @@ export const getCssRules = function(styleSheet: CSSStyleSheet) {
  * @returns
  */
 export const supportRules = function(styleSheet: CSSStyleSheet) {
-    try {
-        const rules = getCssRules(styleSheet)
-        return rules.length > 0
-    } catch (_) {
-        return false
-    }
+    const rules = getCssRules(styleSheet)
+    return !!rules
 }
 
 /**

--- a/test/retry-async.test.ts
+++ b/test/retry-async.test.ts
@@ -1,0 +1,43 @@
+import initAsync from '../src/retry-async'
+import { innerScriptProp, innerOnloadProp, innerOnerrorProp } from '../src/constants'
+const originalCreateElement = document.createElement
+
+describe('initAsync', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    })
+    it('should not break toString functions on DOM methods', () => {
+        initAsync({ domain: { localhost: 'localhost' }, maxRetryCount: 1, onRetry: x => x })
+        expect(document.createElement.toString()).toMatch(/native code/)
+        expect(document.body.appendChild.toString()).toMatch(/native code/)
+        expect(document.body.append.toString()).toMatch(/native code/)
+    })
+    it("should not break normal DOM functions", () => {
+        const $script = originalCreateElement.call(document, 'script');
+        document.body.append($script)
+        expect(document.body.innerHTML).toBe("<script></script>")
+        
+        const $div = document.createElement('div')
+        // support null as argument
+        document.body.insertBefore($div, null);
+        expect(document.body.innerHTML).toBe("<script></script><div></div>")
+    })
+    it('can append HookedScript to DOM', () => {
+        const hookedScript = document.createElement('script') as any;
+        expect(hookedScript[innerScriptProp]).toBeInstanceOf(HTMLScriptElement)
+        document.body.append(hookedScript);
+        expect(document.body.innerHTML).toBe("<script data-assets-retry-hooked=\"true\"></script>")
+    })
+    it('should set property on the real script element', () => {
+        const hookedScript = document.createElement('script') as any;
+        hookedScript.src = 'http://localhost/'
+        hookedScript.onload = jest.fn()
+        hookedScript.onerror = jest.fn()
+        expect(typeof hookedScript[innerOnloadProp]).toBe('function')
+        expect(typeof hookedScript[innerOnerrorProp]).toBe('function')
+        expect(hookedScript[innerScriptProp].src).toBe('http://localhost/')
+        expect(hookedScript.src).toBe('http://localhost/')
+        expect(typeof hookedScript[innerScriptProp].onload).toBe('function')
+        expect(typeof hookedScript.onload).toBe('function')
+    })
+})


### PR DESCRIPTION
1. fix error when calling Node#insertBefore with null as 2nd argument
2. fix error when loading cross origin stylesheets without `crossorigin="anonymous"`