### PR TITLE
fix retry sync script: convert opts.domain to domainMap

### DIFF
--- a/src/retry-sync.ts
+++ b/src/retry-sync.ts
@@ -1,6 +1,6 @@
 import { stringReplace, loadNextScript, loadNextLink, hashTarget, randomString, arrayFrom, getCssRules } from './util'
 import { InnerAssetsRetryOptions } from './assets-retry'
-import { extractInfoFromUrl } from './url'
+import { extractInfoFromUrl, prepareDomainMap } from './url'
 import {
     retryTimesProp,
     failedProp,
@@ -44,7 +44,7 @@ export default function initSync(opts: InnerAssetsRetryOptions) {
             return
         }
         const target = event.target || event.srcElement
-        const domainMap = opts.domain
+        const domainMap = prepareDomainMap(opts.domain)
         const originalUrl = getTargetUrl(target)
         if (!originalUrl) {
             // not one of script / link / image element


### PR DESCRIPTION
问题表现：/e2e/fixture/views/script-sync测试页面中，重试加载vendor.js失败。
原因：重试地址的 URL拼接错误，由于domain支持Object和Array类型，需要将array类型预处理为domainMap。errorHandler中domain忘记调用prepareDomainMap预处理Array类型的入参。