### PR TITLE
feat: add processing of existing elements 

### DIFF
--- a/src/retry-async.ts
+++ b/src/retry-async.ts
@@ -170,7 +170,11 @@ const createHookedElement = function(
 const hookCreateElement = function(opts: InnerAssetsRetryOptions) {
     const originalCreateElement = doc.createElement
     ;(doc as any).createElement = function(name: string, options: any): any {
-        if (name === scriptTag || name === linkTag) {
+        if (name === scriptTag) {
+            // do not proxy script elements to avoid breaking consumers expecting real Nodes
+            return originalCreateElement.call(doc, name, options)
+        }
+        if (name === linkTag) {
             return createHookedElement((originalCreateElement as any).call(doc, name), opts)
         }
         return originalCreateElement.call(doc, name, options)

--- a/src/retry-sync.ts
+++ b/src/retry-sync.ts
@@ -177,21 +177,7 @@ export default function initSync(opts: InnerAssetsRetryOptions) {
     // Process already loaded elements when script initializes
     // This handles the case when assets-retry is loaded at the bottom of the page
     const processExistingElements = () => {
-        const scripts = arrayFrom(doc.querySelectorAll('script[src]')) as HTMLScriptElement[]
         const links = arrayFrom(doc.querySelectorAll('link[rel="stylesheet"][href]')) as HTMLLinkElement[]
-        const images = arrayFrom(doc.querySelectorAll('img[src]')) as HTMLImageElement[]
-        
-        // Check scripts - if they didn't execute, they likely failed
-        scripts.forEach(element => {
-            const url = getTargetUrl(element)
-            if (!url) return
-            
-            const [currentDomain, currentCollector] = extractInfoFromUrl(url, domainMap)
-            if (!currentCollector || !currentDomain) return
-            
-            // Assume script loaded successfully (we can't easily detect failure after the fact)
-            currentCollector[succeededProp].push(url)
-        })
         
         // Check stylesheets - we can detect failed stylesheets by checking their rules
         links.forEach(element => {
@@ -226,27 +212,6 @@ export default function initSync(opts: InnerAssetsRetryOptions) {
             }
         })
         
-        // Check images - look for broken images
-        images.forEach(element => {
-            const url = getTargetUrl(element)
-            if (!url) return
-            
-            const [currentDomain, currentCollector] = extractInfoFromUrl(url, domainMap)
-            if (!currentCollector || !currentDomain) return
-            
-            if (element.hasAttribute(ignoreIdentifier)) return
-            
-            // Check if image failed to load
-            // naturalWidth and naturalHeight are 0 for failed images (after load attempt)
-            if (element.complete && (!element.naturalWidth || !element.naturalHeight)) {
-                // Image failed to load - trigger retry
-                errorHandler({ target: element, srcElement: element } as any)
-            } else if (element.complete) {
-                // Image loaded successfully
-                currentCollector[succeededProp].push(url)
-            }
-            // If not complete yet, we'll catch it in the error/load handlers
-        })
     }
     
     // Process existing elements after DOM is ready

--- a/src/retry-sync.ts
+++ b/src/retry-sync.ts
@@ -212,7 +212,7 @@ export default function initSync(opts: InnerAssetsRetryOptions) {
                     const rules = getCssRules(targetStyleSheet)
                     // If stylesheet has no rules, it might have failed or be empty
                     // Only retry if we can't access rules (which indicates load failure)
-                    if (rules === null) {
+                    if (rules === null || rules.length === 0) {
                         // Failed to load - trigger retry
                         errorHandler({ target: element, srcElement: element } as any)
                         return

--- a/src/retry-sync.ts
+++ b/src/retry-sync.ts
@@ -173,4 +173,87 @@ export default function initSync(opts: InnerAssetsRetryOptions) {
 
     doc.addEventListener('error', errorHandler, true)
     doc.addEventListener('load', loadHandler, true)
+    
+    // Process already loaded elements when script initializes
+    // This handles the case when assets-retry is loaded at the bottom of the page
+    const processExistingElements = () => {
+        const scripts = arrayFrom(doc.querySelectorAll('script[src]')) as HTMLScriptElement[]
+        const links = arrayFrom(doc.querySelectorAll('link[rel="stylesheet"][href]')) as HTMLLinkElement[]
+        const images = arrayFrom(doc.querySelectorAll('img[src]')) as HTMLImageElement[]
+        
+        // Check scripts - if they didn't execute, they likely failed
+        scripts.forEach(element => {
+            const url = getTargetUrl(element)
+            if (!url) return
+            
+            const [currentDomain, currentCollector] = extractInfoFromUrl(url, domainMap)
+            if (!currentCollector || !currentDomain) return
+            
+            // Assume script loaded successfully (we can't easily detect failure after the fact)
+            currentCollector[succeededProp].push(url)
+        })
+        
+        // Check stylesheets - we can detect failed stylesheets by checking their rules
+        links.forEach(element => {
+            const url = getTargetUrl(element)
+            if (!url || element.getAttribute('rel') !== 'stylesheet') return
+            
+            const [currentDomain, currentCollector] = extractInfoFromUrl(url, domainMap)
+            if (!currentCollector || !currentDomain) return
+            
+            if (element.hasAttribute(ignoreIdentifier)) return
+            
+            // Try to find the stylesheet and check if it loaded
+            if (doc.styleSheets) {
+                const styleSheets = arrayFrom(doc.styleSheets) as any[]
+                const targetStyleSheet = styleSheets.find(sheet => sheet.href === element.href)
+                
+                if (targetStyleSheet) {
+                    const rules = getCssRules(targetStyleSheet)
+                    // If stylesheet has no rules, it might have failed or be empty
+                    // Only retry if we can't access rules (which indicates load failure)
+                    if (rules === null) {
+                        // Failed to load - trigger retry
+                        errorHandler({ target: element, srcElement: element } as any)
+                        return
+                    }
+                    // Successfully loaded
+                    currentCollector[succeededProp].push(url)
+                } else {
+                    // Stylesheet not found in styleSheets - likely failed to load
+                    errorHandler({ target: element, srcElement: element } as any)
+                }
+            }
+        })
+        
+        // Check images - look for broken images
+        images.forEach(element => {
+            const url = getTargetUrl(element)
+            if (!url) return
+            
+            const [currentDomain, currentCollector] = extractInfoFromUrl(url, domainMap)
+            if (!currentCollector || !currentDomain) return
+            
+            if (element.hasAttribute(ignoreIdentifier)) return
+            
+            // Check if image failed to load
+            // naturalWidth and naturalHeight are 0 for failed images (after load attempt)
+            if (element.complete && (!element.naturalWidth || !element.naturalHeight)) {
+                // Image failed to load - trigger retry
+                errorHandler({ target: element, srcElement: element } as any)
+            } else if (element.complete) {
+                // Image loaded successfully
+                currentCollector[succeededProp].push(url)
+            }
+            // If not complete yet, we'll catch it in the error/load handlers
+        })
+    }
+    
+    // Process existing elements after DOM is ready
+    if (doc.readyState === 'loading') {
+        doc.addEventListener('DOMContentLoaded', processExistingElements)
+    } else {
+        // DOM already loaded - process immediately
+        processExistingElements()
+    }
 }


### PR DESCRIPTION
Solve Problem
The library couldn't handle assets that already existed on the page before initialization. When assets-retry was loaded at the bottom of the page, it would miss any resources that had already failed to load, since the error event listeners were added too late.